### PR TITLE
Fix NotFound link and cleanup logs

### DIFF
--- a/src/components/PeopleSection.tsx
+++ b/src/components/PeopleSection.tsx
@@ -6,8 +6,6 @@ import { ExternalLink } from 'lucide-react';
 import { people } from '@/data/people';
 
 const PeopleSection: React.FC = () => {
-  console.log('PeopleSection rendering');
-  console.log('People data:', people);
   
   return (
     <section id="people" className="py-20 px-4 bg-muted/20">

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom";
+import { useLocation, Link } from "react-router-dom";
 import { useEffect } from "react";
 
 const NotFound = () => {
@@ -16,9 +16,9 @@ const NotFound = () => {
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+        <Link to="/" className="text-blue-500 hover:text-blue-700 underline">
           Return to Home
-        </a>
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- fix base path navigation on 404 page
- remove debugging logs from `PeopleSection`

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864573536748320a4707363613b0505