### PR TITLE
Add night theme

### DIFF
--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -9,7 +9,8 @@ const ThemeSwitcher: React.FC = () => {
   const themes = [
     { key: 'minimalist', name: 'Minimal', icon: '◯' },
     { key: 'retro', name: 'Retro', icon: '▣' },
-    { key: 'neon', name: 'Neon', icon: '◈' }
+    { key: 'neon', name: 'Neon', icon: '◈' },
+    { key: 'night', name: 'Night', icon: '☾' }
   ] as const;
 
   return (

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,7 +1,7 @@
 
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
-type Theme = 'minimalist' | 'retro' | 'neon';
+type Theme = 'minimalist' | 'retro' | 'neon' | 'night';
 
 interface ThemeContextType {
   theme: Theme;
@@ -16,7 +16,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   useEffect(() => {
     // Load theme from localStorage
     const savedTheme = localStorage.getItem('jonty-hub-theme') as Theme;
-    if (savedTheme && ['minimalist', 'retro', 'neon'].includes(savedTheme)) {
+    if (savedTheme && ['minimalist', 'retro', 'neon', 'night'].includes(savedTheme)) {
       setTheme(savedTheme);
     }
   }, []);

--- a/src/index.css
+++ b/src/index.css
@@ -74,6 +74,29 @@
     --ring: 180 100% 50%;
   }
 
+  /* Night Theme */
+  :root[data-theme='night'] {
+    --background: 222 47% 11%;
+    --foreground: 210 40% 98%;
+    --card: 224 47% 13%;
+    --card-foreground: 210 40% 98%;
+    --popover: 224 47% 13%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 220 90% 55%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 217 32% 17%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 215 25% 27%;
+    --muted-foreground: 215 20% 70%;
+    --accent: 220 90% 55%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 72% 51%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 215 32% 27%;
+    --input: 215 32% 27%;
+    --ring: 220 90% 55%;
+  }
+
   * {
     @apply border-border;
   }
@@ -94,6 +117,10 @@
 
   :root[data-theme='neon'] body {
     font-family: 'Inter Tight', sans-serif;
+  }
+
+  :root[data-theme='night'] body {
+    font-family: var(--font-system);
   }
 
   :root[data-theme='retro'] * {


### PR DESCRIPTION
## Summary
- extend theme types and load logic to support `night`
- add `Night` option in the theme switcher
- define variables and body fonts for new theme

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6864593635bc8320804b7607a2074849