### PR TITLE
Improve theme toggle and hero styling

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,8 +1,9 @@
 
-import React from 'react';
+import React from 'react'
 import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 import ContactPopover from './ContactPopover';
+import { useTheme } from '@/contexts/ThemeContext'
 
 const Hero: React.FC = () => {
   const scrollToSection = (href: string) => {
@@ -12,8 +13,13 @@ const Hero: React.FC = () => {
     }
   };
 
+  const { theme } = useTheme()
+
   return (
-    <section id="hero" className="min-h-screen flex items-center justify-center px-4">
+    <section
+      id="hero"
+      className={`min-h-screen flex items-center justify-center px-4 ${theme === 'night' ? 'bg-gradient-to-br from-slate-900 via-gray-900 to-slate-800' : ''}`}
+    >
       <div className="text-center max-w-4xl mx-auto">
         <motion.div
           initial={{ scale: 0 }}
@@ -27,7 +33,7 @@ const Hero: React.FC = () => {
         </motion.div>
 
         <motion.h1
-          className="text-4xl md:text-6xl font-bold mb-6 bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent"
+          className="text-4xl md:text-6xl font-bold tracking-tight mb-6 bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.3, duration: 0.8 }}
@@ -36,7 +42,7 @@ const Hero: React.FC = () => {
         </motion.h1>
 
         <motion.p
-          className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto"
+          className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto tracking-wide"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.5, duration: 0.8 }}

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -1,34 +1,24 @@
-
-import React from 'react';
-import { useTheme } from '@/contexts/ThemeContext';
-import { Button } from '@/components/ui/button';
+import React from 'react'
+import { useTheme } from '@/contexts/ThemeContext'
+import { Switch } from '@/components/ui/switch'
+import { Sun, Moon } from 'lucide-react'
 
 const ThemeSwitcher: React.FC = () => {
-  const { theme, setTheme } = useTheme();
+  const { theme, setTheme } = useTheme()
 
-  const themes = [
-    { key: 'minimalist', name: 'Minimal', icon: '◯' },
-    { key: 'retro', name: 'Retro', icon: '▣' },
-    { key: 'neon', name: 'Neon', icon: '◈' },
-    { key: 'night', name: 'Night', icon: '☾' }
-  ] as const;
+  const isNight = theme === 'night'
+
+  const toggleTheme = (checked: boolean) => {
+    setTheme(checked ? 'night' : 'minimal')
+  }
 
   return (
-    <div className="flex gap-1 bg-secondary/50 p-1 rounded-lg">
-      {themes.map((t) => (
-        <Button
-          key={t.key}
-          variant={theme === t.key ? "default" : "ghost"}
-          size="sm"
-          onClick={() => setTheme(t.key)}
-          className="text-xs px-2 py-1 transition-all duration-200 hover:scale-105"
-        >
-          <span className="mr-1">{t.icon}</span>
-          {t.name}
-        </Button>
-      ))}
+    <div className="flex items-center space-x-2">
+      <Sun className="h-4 w-4 text-yellow-500" />
+      <Switch checked={isNight} onCheckedChange={toggleTheme} />
+      <Moon className="h-4 w-4 text-blue-500" />
     </div>
-  );
-};
+  )
+}
 
-export default ThemeSwitcher;
+export default ThemeSwitcher

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,7 +1,7 @@
 
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react'
 
-type Theme = 'minimalist' | 'retro' | 'neon' | 'night';
+type Theme = 'minimal' | 'night'
 
 interface ThemeContextType {
   theme: Theme;
@@ -11,20 +11,24 @@ interface ThemeContextType {
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [theme, setTheme] = useState<Theme>('minimalist');
+  const [theme, setTheme] = useState<Theme>('minimal');
 
   useEffect(() => {
     // Load theme from localStorage
-    const savedTheme = localStorage.getItem('jonty-hub-theme') as Theme;
-    if (savedTheme && ['minimalist', 'retro', 'neon', 'night'].includes(savedTheme)) {
-      setTheme(savedTheme);
+    const savedTheme = localStorage.getItem('jonty-hub-theme') as Theme
+    if (savedTheme && ['minimal', 'night'].includes(savedTheme)) {
+      setTheme(savedTheme)
     }
   }, []);
 
   useEffect(() => {
     // Apply theme to document
-    document.documentElement.setAttribute('data-theme', theme);
-    localStorage.setItem('jonty-hub-theme', theme);
+    const root = document.documentElement
+    root.classList.add('theme-transition')
+    root.setAttribute('data-theme', theme)
+    localStorage.setItem('jonty-hub-theme', theme)
+    const timeout = setTimeout(() => root.classList.remove('theme-transition'), 300)
+    return () => clearTimeout(timeout)
   }, [theme]);
 
   return (

--- a/src/index.css
+++ b/src/index.css
@@ -6,20 +6,20 @@
 /* Theme Variables */
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    --background: 0 0% 98%;
+    --foreground: 222.2 47.4% 11.2%;
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 222.2 47.4% 11.2%;
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 222.2 47.4% 11.2%;
+    --popover-foreground: 222.2 47.4% 11.2%;
+    --primary: 220 80% 60%;
     --primary-foreground: 210 40% 98%;
     --secondary: 210 40% 96.1%;
     --secondary-foreground: 222.2 47.4% 11.2%;
     --muted: 210 40% 96.1%;
     --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --accent: 220 90% 55%;
+    --accent-foreground: 210 40% 98%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
     --border: 214.3 31.8% 91.4%;
@@ -28,51 +28,6 @@
     --radius: 0.5rem;
   }
 
-  /* Retro Theme */
-  :root[data-theme='retro'] {
-    --background: 15 15% 6%;
-    --foreground: 120 100% 50%;
-    --card: 0 0% 10%;
-    --card-foreground: 120 100% 50%;
-    --popover: 0 0% 10%;
-    --popover-foreground: 120 100% 50%;
-    --primary: 45 100% 50%;
-    --primary-foreground: 15 15% 6%;
-    --secondary: 0 0% 20%;
-    --secondary-foreground: 120 100% 50%;
-    --muted: 0 0% 15%;
-    --muted-foreground: 120 50% 70%;
-    --accent: 45 100% 50%;
-    --accent-foreground: 15 15% 6%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 0 0% 20%;
-    --input: 0 0% 20%;
-    --ring: 120 100% 50%;
-  }
-
-  /* Neon Theme */
-  :root[data-theme='neon'] {
-    --background: 0 0% 4%;
-    --foreground: 180 100% 50%;
-    --card: 0 0% 8%;
-    --card-foreground: 180 100% 50%;
-    --popover: 0 0% 8%;
-    --popover-foreground: 180 100% 50%;
-    --primary: 300 100% 50%;
-    --primary-foreground: 0 0% 4%;
-    --secondary: 0 0% 12%;
-    --secondary-foreground: 180 100% 50%;
-    --muted: 0 0% 10%;
-    --muted-foreground: 180 50% 70%;
-    --accent: 300 100% 50%;
-    --accent-foreground: 0 0% 4%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 0 0% 15%;
-    --input: 0 0% 15%;
-    --ring: 180 100% 50%;
-  }
 
   /* Night Theme */
   :root[data-theme='night'] {
@@ -97,6 +52,10 @@
     --ring: 220 90% 55%;
   }
 
+  :root[data-theme='night'] #hero {
+    background-image: linear-gradient(to bottom right, #0f172a, #1e293b);
+  }
+
   * {
     @apply border-border;
   }
@@ -106,30 +65,14 @@
   }
 
   /* Theme-specific styles */
-  :root[data-theme='minimalist'] body {
-    font-family: var(--font-system);
-  }
-
-  :root[data-theme='retro'] body {
-    font-family: 'IBM Plex Mono', monospace;
-    cursor: url('data:image/gif;base64,R0lGODlhEAAQAPIAAAAAAP///wAAACH5BAEAAAIALAAAAAAQABAAAAMkaLocLrd/1koJEpxOYSvNnz3ZJHKgFRlmJLHVDqxMNGUKOGMvMJQCADs='), auto;
-  }
-
-  :root[data-theme='neon'] body {
+  :root[data-theme='minimal'] body {
     font-family: 'Inter Tight', sans-serif;
   }
 
   :root[data-theme='night'] body {
-    font-family: var(--font-system);
+    font-family: 'Inter Tight', sans-serif;
   }
 
-  :root[data-theme='retro'] * {
-    border-style: dotted !important;
-  }
-
-  :root[data-theme='neon'] .card {
-    box-shadow: 0 0 20px hsl(var(--accent) / 0.3);
-  }
 
   /* Skip to content link */
   .skip-link {
@@ -168,4 +111,9 @@
   background: hsl(var(--primary));
   pointer-events: none;
   z-index: 1000;
+}
+
+/* Smooth theme transition */
+.theme-transition {
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -53,24 +53,11 @@ export default {
 					DEFAULT: 'hsl(var(--card))',
 					foreground: 'hsl(var(--card-foreground))'
 				},
-				retro: {
-					bg: '#0f0f0f',
-					green: '#00ff41',
-					amber: '#ffb000',
-					gray: '#333333'
-				},
-				neon: {
-					bg: '#0a0a0a',
-					cyan: '#00ffff',
-					magenta: '#ff00ff',
-					purple: '#8b5cf6'
-				}
+                                
 			},
-			fontFamily: {
-				'system': ['system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'sans-serif'],
-				'retro': ['IBM Plex Mono', 'monospace'],
-				'neon': ['Inter Tight', 'sans-serif']
-			},
+                        fontFamily: {
+                                'system': ['Inter Tight', 'sans-serif']
+                        },
 			borderRadius: {
 				lg: 'var(--radius)',
 				md: 'calc(var(--radius) - 2px)',


### PR DESCRIPTION
## Summary
- simplify themes to "minimal" and "night"
- add smooth theme transition and persist preference
- introduce a modern switch component for theme selection
- update hero section and general styles for new palettes
- drop unused retro/neon theme assets and fonts

## Testing
- `npm run lint` *(fails: cannot find packages)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68645e60ae74832099b0680b93e3f7db