### PR TITLE
Improve responsive layout

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -27,7 +27,7 @@ const Hero: React.FC = () => {
           transition={{ duration: 0.8, type: "spring", bounce: 0.4 }}
           className="mb-8"
         >
-          <div className="w-32 h-32 mx-auto bg-gradient-to-br from-primary to-accent rounded-full flex items-center justify-center text-6xl text-primary-foreground font-bold shadow-2xl">
+          <div className="w-24 h-24 sm:w-32 sm:h-32 md:w-40 md:h-40 mx-auto bg-gradient-to-br from-primary to-accent rounded-full flex items-center justify-center text-5xl sm:text-6xl md:text-7xl text-primary-foreground font-bold shadow-2xl">
             J
           </div>
         </motion.div>

--- a/src/components/PlaylistsSection.tsx
+++ b/src/components/PlaylistsSection.tsx
@@ -37,7 +37,7 @@ const PlaylistsSection: React.FC = () => {
             </CardHeader>
             <CardContent>
               <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-                <TabsList className="grid w-full grid-cols-3 md:grid-cols-6 mb-6">
+                <TabsList className="grid w-full grid-cols-2 sm:grid-cols-3 md:grid-cols-6 mb-6">
                   {playlists.map((playlist, index) => (
                     <motion.div
                       key={`playlist-${index}`}
@@ -60,7 +60,7 @@ const PlaylistsSection: React.FC = () => {
                     value={`playlist-${index}`}
                     className="mt-0"
                   >
-                    <div className="w-full h-[380px]">
+                    <div className="w-full h-60 sm:h-72 md:h-[380px]">
                       <iframe
                         src={playlist.spotifyUrl}
                         width="100%"
@@ -68,7 +68,7 @@ const PlaylistsSection: React.FC = () => {
                         frameBorder="0"
                         allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
                         loading={activeTab === `playlist-${index}` ? "eager" : "lazy"}
-                        className="rounded-lg border border-border"
+                        className="rounded-lg border border-border w-full h-full"
                       ></iframe>
                     </div>
                   </TabsContent>

--- a/src/components/PodcastsSection.tsx
+++ b/src/components/PodcastsSection.tsx
@@ -80,7 +80,7 @@ const PodcastsSection: React.FC = () => {
                       className="mt-0"
                     >
                       {podcast.embedUrl ? (
-                        <div className="w-full h-[232px]">
+                        <div className="w-full h-40 sm:h-52 md:h-[232px]">
                           <iframe
                             src={podcast.embedUrl}
                             width="100%"
@@ -88,7 +88,7 @@ const PodcastsSection: React.FC = () => {
                             frameBorder="0"
                             allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
                             loading={activeTab === podcast.id ? "eager" : "lazy"}
-                            className="rounded-lg border border-border"
+                            className="rounded-lg border border-border w-full h-full"
                           ></iframe>
                         </div>
                       ) : (
@@ -97,7 +97,7 @@ const PodcastsSection: React.FC = () => {
                           animate={{ opacity: 1, y: 0 }}
                           exit={{ opacity: 0, y: 20 }}
                           transition={{ duration: 0.4 }}
-                          className="flex items-center justify-center h-[232px] bg-muted/50 rounded-lg border border-border"
+                          className="flex items-center justify-center h-40 sm:h-52 md:h-[232px] bg-muted/50 rounded-lg border border-border"
                         >
                           <p className="text-muted-foreground text-center max-w-md px-6 leading-relaxed">
                             The mega-shows everybody quotes? I skim them, but not often enough to give them real estate here.

--- a/src/index.css
+++ b/src/index.css
@@ -64,6 +64,10 @@
     @apply bg-background text-foreground transition-colors duration-300;
   }
 
+  #root {
+    @apply max-w-7xl mx-auto px-4 sm:px-6 lg:px-8;
+  }
+
   /* Theme-specific styles */
   :root[data-theme='minimal'] body {
     font-family: 'Inter Tight', sans-serif;


### PR DESCRIPTION
## Summary
- tune hero avatar sizes for small/large screens
- make playlist tabs and embeds responsive
- tweak podcast embed heights
- constrain root container with responsive padding

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6864692c0dd88320bb08ab60e1923c8c