### PR TITLE
Implement horizontal scrolling purchases

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "cmdk": "^1.0.0",
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.3.0",
+    "gsap": "^3.12.5",
     "framer-motion": "^12.19.2",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",

--- a/src/components/PurchasesSection.tsx
+++ b/src/components/PurchasesSection.tsx
@@ -1,13 +1,43 @@
 
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { motion } from 'framer-motion';
+import gsap from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
 import { Card, CardContent } from '@/components/ui/card';
-import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from '@/components/ui/carousel';
 import { purchases } from '@/data/purchases';
 
 const PurchasesSection: React.FC = () => {
+  const sectionRef = useRef<HTMLDivElement>(null);
+  const trackRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    gsap.registerPlugin(ScrollTrigger);
+    const section = sectionRef.current;
+    const track = trackRef.current;
+    if (!section || !track) return;
+
+    const totalScroll = track.scrollWidth - section.clientWidth;
+
+    const ctx = gsap.context(() => {
+      gsap.to(track, {
+        x: -totalScroll,
+        ease: "none",
+        scrollTrigger: {
+          trigger: section,
+          start: "top top",
+          end: () => `+=${totalScroll}`,
+          scrub: true,
+          pin: true,
+          invalidateOnRefresh: true,
+        },
+      });
+    }, section);
+
+    return () => ctx.revert();
+  }, []);
+
   return (
-    <section className="py-20 px-4 bg-muted/20">
+    <section ref={sectionRef} className="py-20 px-4 bg-muted/20 overflow-hidden">
       <div className="container mx-auto max-w-6xl">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -22,37 +52,33 @@ const PurchasesSection: React.FC = () => {
           </p>
         </motion.div>
 
-        <Carousel className="relative" opts={{ align: 'start' }}>
-          <CarouselContent>
-            {purchases.map((purchase, index) => (
-              <CarouselItem key={purchase.item} className="md:basis-1/3">
-                <motion.div
-                  initial={{ opacity: 0, scale: 0.8 }}
-                  whileInView={{ opacity: 1, scale: 1 }}
-                  transition={{ duration: 0.6, delay: index * 0.1 }}
-                  viewport={{ once: true }}
-                  whileHover={{ scale: 1.05, rotateY: 5 }}
-                >
-                  <Card className="overflow-hidden hover:shadow-lg transition-all duration-300">
-                    <div className="aspect-square relative overflow-hidden">
-                      <img
-                        src={purchase.image}
-                        alt={purchase.item}
-                        className="w-full h-full object-cover transition-transform duration-300 hover:scale-110"
-                      />
-                    </div>
-                    <CardContent className="p-4">
-                      <h3 className="font-semibold mb-2">{purchase.item}</h3>
-                      <p className="text-muted-foreground text-sm">{purchase.why}</p>
-                    </CardContent>
-                  </Card>
-                </motion.div>
-              </CarouselItem>
-            ))}
-          </CarouselContent>
-          <CarouselPrevious />
-          <CarouselNext />
-        </Carousel>
+        <div ref={trackRef} className="flex gap-4">
+          {purchases.map((purchase, index) => (
+            <motion.div
+              key={purchase.item}
+              className="w-[300px] shrink-0"
+              initial={{ opacity: 0, scale: 0.8 }}
+              whileInView={{ opacity: 1, scale: 1 }}
+              transition={{ duration: 0.6, delay: index * 0.1 }}
+              viewport={{ once: true }}
+              whileHover={{ scale: 1.05, rotateY: 5 }}
+            >
+              <Card className="overflow-hidden hover:shadow-lg transition-all duration-300">
+                <div className="aspect-square relative overflow-hidden">
+                  <img
+                    src={purchase.image}
+                    alt={purchase.item}
+                    className="w-full h-full object-cover transition-transform duration-300 hover:scale-110"
+                  />
+                </div>
+                <CardContent className="p-4">
+                  <h3 className="font-semibold mb-2">{purchase.item}</h3>
+                  <p className="text-muted-foreground text-sm">{purchase.why}</p>
+                </CardContent>
+              </Card>
+            </motion.div>
+          ))}
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- add `gsap` to dependencies
- rework `PurchasesSection` to use GSAP `ScrollTrigger` for a pinned horizontal scroll effect

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6865a65332548320a9c08d8cda9a74b8