### PR TITLE
Fix scrolling timing for purchase carousel

### DIFF
--- a/src/components/PurchasesSection.tsx
+++ b/src/components/PurchasesSection.tsx
@@ -24,10 +24,9 @@ const PurchasesSection: React.FC = () => {
         ease: "none",
         scrollTrigger: {
           trigger: section,
-          start: "top top",
-          end: () => `+=${totalScroll}`,
+          start: "top bottom",
+          end: "bottom top",
           scrub: true,
-          pin: true,
           invalidateOnRefresh: true,
         },
       });


### PR DESCRIPTION
## Summary
- let PurchasesSection's carousel scroll horizontally with the page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865bc09231083208b7434b213434490