### PR TITLE
Ensure blog detail starts at top

### DIFF
--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import Navigation from '@/components/Navigation'
@@ -18,6 +18,10 @@ import { blogArticles, getArticleBySlug } from '@/data/blogArticles'
 const BlogPost: React.FC = () => {
   const { slug } = useParams<{ slug: string }>()
   const article = getArticleBySlug(slug ?? '')
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: 'smooth' })
+  }, [slug])
 
   if (!article) {
     return (


### PR DESCRIPTION
## Summary
- scroll to top whenever navigating to a blog detail

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68669273c8bc83208c8f0eb44b48d423