### PR TITLE
Add blog carousel

### DIFF
--- a/src/components/BlogSection.tsx
+++ b/src/components/BlogSection.tsx
@@ -5,7 +5,6 @@ import { Link } from 'react-router-dom';
 import {
   Card,
   CardContent,
-  CardDescription,
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
@@ -13,6 +12,14 @@ import { Badge } from '@/components/ui/badge';
 import { blogPosts } from '@/data/blogPosts';
 import type { LucideIcon } from 'lucide-react';
 import { Cpu, Video, PenTool, Activity, Smile, Settings } from 'lucide-react';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+  type CarouselApi,
+} from '@/components/ui/carousel';
 
 const categoryIcons: Record<string, LucideIcon> = {
   AI: Cpu,
@@ -28,6 +35,22 @@ const getIcon = (category: string): LucideIcon => {
 };
 
 const BlogSection: React.FC = () => {
+  const maxScrolls = 3
+  const [scrollCount, setScrollCount] = React.useState(0)
+  const apiRef = React.useRef<CarouselApi | null>(null)
+
+  const handleNext = () => {
+    if (scrollCount >= maxScrolls) return
+    apiRef.current?.scrollNext()
+    setScrollCount((c) => Math.min(c + 1, maxScrolls))
+  }
+
+  const handlePrev = () => {
+    if (scrollCount <= 0) return
+    apiRef.current?.scrollPrev()
+    setScrollCount((c) => Math.max(c - 1, 0))
+  }
+
   return (
     <section id="blog" className="py-20 px-4 bg-muted/20">
       <div className="container mx-auto max-w-6xl">
@@ -44,52 +67,80 @@ const BlogSection: React.FC = () => {
           </p>
         </motion.div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
-          {blogPosts.map((post, index) => {
-            const Icon = getIcon(post.category);
-            return (
-              <motion.div
-                key={post.title}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true }}
-                whileHover={{ scale: 1.03, boxShadow: '0 8px 20px rgba(0,0,0,0.08)' }}
-              >
-                <Link to={post.url} className="block h-full group">
-                  <Card className="h-full flex flex-col border border-border/80 rounded-lg overflow-hidden hover:shadow-lg transition-colors">
-                    <CardHeader className="pb-4 flex items-start gap-3">
-                      <div className="p-2 rounded-md bg-muted/50">
-                        <Icon className="w-5 h-5 text-primary" />
-                      </div>
-                      <div className="flex-1 space-y-1">
-                        <CardTitle className="text-lg md:text-xl group-hover:text-primary">
-                          {post.title}
-                        </CardTitle>
-                        <p className="text-sm text-muted-foreground italic">
-                          {new Date(post.date).toLocaleDateString()}
-                        </p>
-                      </div>
-                    </CardHeader>
-                    <CardContent className="flex-1 flex flex-col space-y-4">
-                      <p className="text-muted-foreground leading-relaxed">
-                        {post.excerpt}
-                      </p>
-                      <div className="mt-auto">
-                        <Badge variant="outline" className="mb-2">
-                          {post.category}
-                        </Badge>
-                        <p className="text-primary font-medium group-hover:underline">
-                          Read More →
-                        </p>
-                      </div>
-                    </CardContent>
-                  </Card>
-                </Link>
-              </motion.div>
-            );
-          })}
-        </div>
+        <Carousel setApi={(api) => (apiRef.current = api)} className="relative">
+          <CarouselContent className="cursor-grab">
+            {blogPosts.map((post, index) => {
+              const Icon = getIcon(post.category)
+              return (
+                <CarouselItem
+                  key={post.title}
+                  className="basis-full md:basis-1/4"
+                >
+                  <motion.div
+                    initial={{ opacity: 0, y: 20 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.6, delay: index * 0.1 }}
+                    viewport={{ once: true }}
+                    whileHover={{ scale: 1.03, boxShadow: '0 8px 20px rgba(0,0,0,0.08)' }}
+                  >
+                    <Link to={post.url} className="block h-full group">
+                      <Card className="h-full flex flex-col border border-border/80 rounded-lg overflow-hidden hover:shadow-lg transition-colors">
+                        <CardHeader className="pb-4 flex items-start gap-3">
+                          <div className="p-2 rounded-md bg-muted/50">
+                            <Icon className="w-5 h-5 text-primary" />
+                          </div>
+                          <div className="flex-1 space-y-1">
+                            <CardTitle className="text-lg md:text-xl group-hover:text-primary">
+                              {post.title}
+                            </CardTitle>
+                            <p className="text-sm text-muted-foreground italic">
+                              {new Date(post.date).toLocaleDateString()}
+                            </p>
+                          </div>
+                        </CardHeader>
+                        <CardContent className="flex-1 flex flex-col space-y-4">
+                          <p className="text-muted-foreground leading-relaxed">
+                            {post.excerpt}
+                          </p>
+                          <div className="mt-auto">
+                            <Badge variant="outline" className="mb-2">
+                              {post.category}
+                            </Badge>
+                            <p className="text-primary font-medium group-hover:underline">
+                              Read More →
+                            </p>
+                          </div>
+                        </CardContent>
+                      </Card>
+                    </Link>
+                  </motion.div>
+                </CarouselItem>
+              )
+            })}
+            <CarouselItem className="basis-full md:basis-1/4">
+              <Link to="/blog" className="block h-full group">
+                <Card className="h-full flex flex-col items-center justify-center border-dashed border-2">
+                  <CardHeader className="pb-2 text-center">
+                    <CardTitle>Show More</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-2xl">→</p>
+                  </CardContent>
+                </Card>
+              </Link>
+            </CarouselItem>
+          </CarouselContent>
+          <CarouselPrevious
+            onClick={handlePrev}
+            disabled={scrollCount === 0}
+            className="left-0 top-1/2 -translate-y-1/2"
+          />
+          <CarouselNext
+            onClick={handleNext}
+            disabled={scrollCount === maxScrolls}
+            className="right-0 top-1/2 -translate-y-1/2"
+          />
+        </Carousel>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- convert blog section grid to carousel
- add prev/next buttons with scroll limits
- include a final 'Show More' card

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867a865ed608320b4531d929e8d103b